### PR TITLE
ci: :construction_worker: use Seedcase's add to project board workflow

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,4 +1,4 @@
-name: Assign items and add to project
+name: Add to project board
 
 on:
   issues:
@@ -16,8 +16,9 @@ permissions:
 
 jobs:
   add-to-project:
-    uses: rostools/.github/.github/workflows/reusable-add-to-project.yml@main
+    uses: seedcase-project/.github/.github/workflows/reusable-add-to-project.yml@main
     with:
+      app-id: ${{ vars.ADD_TO_BOARD_APP_ID }}
       board-number: 12
     secrets:
       add-to-board-token: ${{ secrets.ADD_TO_BOARD }}


### PR DESCRIPTION
# Description

Centralise the ops work to Seedcase, rather than maintain two workflows